### PR TITLE
Restore themed backgrounds for Markdown code blocks

### DIFF
--- a/sgpt/printer.py
+++ b/sgpt/printer.py
@@ -1,9 +1,14 @@
 from abc import ABC, abstractmethod
 from typing import Generator
 
-from rich.console import Console
+from rich.console import Console, ConsoleOptions
 from rich.live import Live
-from rich.markdown import Markdown
+from rich.markdown import Markdown, CodeBlock
+from rich.text import Text
+from pygments import highlight
+from pygments.formatters import TerminalFormatter
+from pygments.lexers import get_lexer_by_name
+from pygments.styles import get_style_by_name
 from typer import secho
 
 
@@ -27,23 +32,60 @@ class Printer(ABC):
         return full_completion
 
 
+class _ThemedCodeBlock(CodeBlock):
+    """Code block with theme background but without trailing padding."""
+
+    def __rich_console__(self, console: Console, options: ConsoleOptions):
+        code = str(self.text).rstrip()
+        try:
+            lexer = get_lexer_by_name(self.lexer_name)
+        except Exception:
+            lexer = get_lexer_by_name("text")
+        highlighted = highlight(code, lexer, TerminalFormatter())
+        highlighted = highlighted.replace("\x1b[39;49;00m", "\x1b[39m")
+        try:
+            bg = get_style_by_name(self.theme).background_color
+        except Exception:
+            bg = None
+        if bg:
+            r, g, b = int(bg[1:3], 16), int(bg[3:5], 16), int(bg[5:7], 16)
+            bg_code = f"\x1b[48;2;{r};{g};{b}m"
+        else:
+            bg_code = ""
+        lines = highlighted.rstrip("\n").splitlines()
+        block = "".join(f"{bg_code} {line}\n" for line in lines)
+        if bg_code:
+            block += "\x1b[0m"
+        yield Text.from_ansi(block)
+
+
+class _ThemedMarkdown(Markdown):
+    """Markdown renderer using themed code blocks."""
+
+    elements = Markdown.elements | {
+        "fence": _ThemedCodeBlock,
+        "code_block": _ThemedCodeBlock,
+    }
+
+
 class MarkdownPrinter(Printer):
     def __init__(self, theme: str) -> None:
         self.console = Console()
         self.theme = theme
+
+    def _markdown(self, text: str) -> Markdown:
+        return _ThemedMarkdown(markup=text, code_theme=self.theme)
 
     def live_print(self, chunks: Generator[str, None, None]) -> str:
         full_completion = ""
         with Live(console=self.console) as live:
             for chunk in chunks:
                 full_completion += chunk
-                markdown = Markdown(markup=full_completion, code_theme=self.theme)
-                live.update(markdown, refresh=True)
+                live.update(self._markdown(full_completion), refresh=True)
         return full_completion
 
     def static_print(self, text: str) -> str:
-        markdown = Markdown(markup=text, code_theme=self.theme)
-        self.console.print(markdown)
+        self.console.print(self._markdown(text))
         return text
 
 

--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -1,0 +1,21 @@
+from io import StringIO
+
+import re
+from rich.console import Console
+
+from sgpt.printer import MarkdownPrinter
+
+
+def test_markdown_printer_no_trailing_spaces():
+    printer = MarkdownPrinter(theme="monokai")
+    buffer = StringIO()
+    printer.console = Console(file=buffer, force_terminal=True)
+    code_block = """```python\nprint('hi')\n```"""
+    printer.static_print(code_block)
+    rendered = buffer.getvalue()
+    assert re.search(r"\x1b\[(?:48;2;\d+;\d+;\d+|4\d)m", rendered)
+    plain_text = re.sub(r"\x1b\[[0-9;]*m", "", rendered)
+    for line in plain_text.splitlines():
+        if not line.strip():
+            continue
+        assert line == line.rstrip()


### PR DESCRIPTION
## Summary
- render fenced code blocks with the selected theme's background color while trimming right-side padding
- ensure Markdown renderer uses themed code blocks so other elements retain their backgrounds
- test that rendered code blocks contain a background color and no trailing spaces

## Testing
- `OPENAI_API_KEY=dummy pytest tests/test_printer.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68ba6dca46b8832b82258f68c68cf631