### PR TITLE
refactor: extract chat session utilities

### DIFF
--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -14,6 +14,7 @@ from sgpt.function import get_openai_schemas
 from sgpt.handlers.chat_handler import ChatHandler
 from sgpt.handlers.default_handler import DefaultHandler
 from sgpt.handlers.repl_handler import ReplHandler
+from sgpt.chat_session import list_chat_ids, show_chat_messages
 from sgpt.llm_functions.init_functions import install_functions as inst_funcs
 from sgpt.role import DefaultRoles, SystemRole
 from sgpt.utils import (
@@ -115,7 +116,7 @@ def main(
         "--list-chats",
         "-lc",
         help="List all existing chat ids.",
-        callback=ChatHandler.list_ids,
+        callback=list_chat_ids,
         rich_help_panel="Chat Options",
     ),
     role: str = typer.Option(
@@ -184,7 +185,7 @@ def main(
             pass
 
     if show_chat:
-        ChatHandler.show_messages(show_chat, md)
+        show_chat_messages(show_chat, md)
 
     if sum((shell, describe_shell, code)) > 1:
         raise BadArgumentUsage(

--- a/sgpt/chat_session.py
+++ b/sgpt/chat_session.py
@@ -1,0 +1,108 @@
+import json
+from pathlib import Path
+from typing import Any, Callable, Dict, Generator, List, Optional
+
+import typer
+from rich.console import Console
+from rich.markdown import Markdown
+
+from .config import cfg
+
+CHAT_CACHE_LENGTH = int(cfg.get("CHAT_CACHE_LENGTH"))
+CHAT_CACHE_PATH = Path(cfg.get("CHAT_CACHE_PATH"))
+
+
+class ChatSession:
+    """Decorator-based chat session manager that caches messages."""
+
+    def __init__(self, length: int, storage_path: Path) -> None:
+        self.length = length
+        self.storage_path = storage_path
+        self.storage_path.mkdir(parents=True, exist_ok=True)
+
+    def __call__(self, func: Callable[..., Any]) -> Callable[..., Any]:
+        def wrapper(*args: Any, **kwargs: Any) -> Generator[str, None, None]:
+            chat_id = kwargs.pop("chat_id", None)
+            if not kwargs.get("messages"):
+                return
+            if not chat_id:
+                yield from func(*args, **kwargs)
+                return
+            previous_messages = self._read(chat_id)
+            for message in kwargs["messages"]:
+                previous_messages.append(message)
+            kwargs["messages"] = previous_messages
+            response_text = ""
+            for word in func(*args, **kwargs):
+                response_text += word
+                yield word
+            previous_messages.append({"role": "assistant", "content": response_text})
+            self._write(kwargs["messages"], chat_id)
+
+        return wrapper
+
+    def _read(self, chat_id: str) -> List[Dict[str, str]]:
+        file_path = self.storage_path / chat_id
+        if not file_path.exists():
+            return []
+        parsed_cache = json.loads(file_path.read_text())
+        return parsed_cache if isinstance(parsed_cache, list) else []
+
+    def _write(self, messages: List[Dict[str, str]], chat_id: str) -> None:
+        file_path = self.storage_path / chat_id
+        truncated_messages = (
+            messages[:1] + messages[1 + max(0, len(messages) - self.length) :]
+        )
+        json.dump(truncated_messages, file_path.open("w"))
+
+    def invalidate(self, chat_id: str) -> None:
+        file_path = self.storage_path / chat_id
+        file_path.unlink(missing_ok=True)
+
+    def get_messages(self, chat_id: str) -> List[str]:
+        messages = self._read(chat_id)
+        return [f"{message['role']}: {message['content']}" for message in messages]
+
+    def exists(self, chat_id: Optional[str]) -> bool:
+        return bool(chat_id and bool(self._read(chat_id)))
+
+    def list(self) -> List[Path]:
+        files = self.storage_path.glob("*")
+        return sorted(files, key=lambda f: f.stat().st_mtime)
+
+
+chat_session = ChatSession(CHAT_CACHE_LENGTH, CHAT_CACHE_PATH)
+
+
+def initial_message(chat_id: str) -> str:
+    chat_history = chat_session.get_messages(chat_id)
+    return chat_history[0] if chat_history else ""
+
+
+def list_chat_ids(value: bool) -> bool:
+    if not value:
+        return value
+    for chat_id in chat_session.list():
+        typer.echo(chat_id)
+    raise typer.Exit()
+
+
+def show_chat_messages(chat_id: str, markdown: bool) -> None:
+    color = cfg.get("DEFAULT_COLOR")
+    if "APPLY MARKDOWN" in initial_message(chat_id) and markdown:
+        theme = cfg.get("CODE_THEME")
+        for message in chat_session.get_messages(chat_id):
+            if message.startswith("assistant:"):
+                Console().print(Markdown(message, code_theme=theme))
+            else:
+                typer.secho(message, fg=color)
+            typer.echo()
+        return
+
+    for index, message in enumerate(chat_session.get_messages(chat_id)):
+        running_color = color if index % 2 == 0 else "green"
+        typer.secho(message, fg=running_color)
+
+
+def invalidate_chat(chat_id: str) -> None:
+    chat_session.invalidate(chat_id)

--- a/sgpt/handlers/chat_handler.py
+++ b/sgpt/handlers/chat_handler.py
@@ -1,102 +1,18 @@
-import json
-from pathlib import Path
-from typing import Any, Callable, Dict, Generator, List, Optional
+from typing import Any, Dict, Generator, List
 
-import typer
 from click import BadArgumentUsage
-from rich.console import Console
-from rich.markdown import Markdown
 
-from ..config import cfg
 from ..role import DefaultRoles, SystemRole
-from ..utils import option_callback
 from .handler import Handler
-
-CHAT_CACHE_LENGTH = int(cfg.get("CHAT_CACHE_LENGTH"))
-CHAT_CACHE_PATH = Path(cfg.get("CHAT_CACHE_PATH"))
-
-
-class ChatSession:
-    """
-    This class is used as a decorator for OpenAI chat API requests.
-    The ChatSession class caches chat messages and keeps track of the
-    conversation history. It is designed to store cached messages
-    in a specified directory and in JSON format.
-    """
-
-    def __init__(self, length: int, storage_path: Path):
-        """
-        Initialize the ChatSession decorator.
-
-        :param length: Integer, maximum number of cached messages to keep.
-        """
-        self.length = length
-        self.storage_path = storage_path
-        self.storage_path.mkdir(parents=True, exist_ok=True)
-
-    def __call__(self, func: Callable[..., Any]) -> Callable[..., Any]:
-        """
-        The Cache decorator.
-
-        :param func: The chat function to cache.
-        :return: Wrapped function with chat caching.
-        """
-
-        def wrapper(*args: Any, **kwargs: Any) -> Generator[str, None, None]:
-            chat_id = kwargs.pop("chat_id", None)
-            if not kwargs.get("messages"):
-                return
-            if not chat_id:
-                yield from func(*args, **kwargs)
-                return
-            previous_messages = self._read(chat_id)
-            for message in kwargs["messages"]:
-                previous_messages.append(message)
-            kwargs["messages"] = previous_messages
-            response_text = ""
-            for word in func(*args, **kwargs):
-                response_text += word
-                yield word
-            previous_messages.append({"role": "assistant", "content": response_text})
-            self._write(kwargs["messages"], chat_id)
-
-        return wrapper
-
-    def _read(self, chat_id: str) -> List[Dict[str, str]]:
-        file_path = self.storage_path / chat_id
-        if not file_path.exists():
-            return []
-        parsed_cache = json.loads(file_path.read_text())
-        return parsed_cache if isinstance(parsed_cache, list) else []
-
-    def _write(self, messages: List[Dict[str, str]], chat_id: str) -> None:
-        file_path = self.storage_path / chat_id
-        # Retain the first message since it defines the role
-        truncated_messages = (
-            messages[:1] + messages[1 + max(0, len(messages) - self.length) :]
-        )
-        json.dump(truncated_messages, file_path.open("w"))
-
-    def invalidate(self, chat_id: str) -> None:
-        file_path = self.storage_path / chat_id
-        file_path.unlink(missing_ok=True)
-
-    def get_messages(self, chat_id: str) -> List[str]:
-        messages = self._read(chat_id)
-        return [f"{message['role']}: {message['content']}" for message in messages]
-
-    def exists(self, chat_id: Optional[str]) -> bool:
-        return bool(chat_id and bool(self._read(chat_id)))
-
-    def list(self) -> List[Path]:
-        # Get all files in the folder.
-        files = self.storage_path.glob("*")
-        # Sort files by last modification time in ascending order.
-        return sorted(files, key=lambda f: f.stat().st_mtime)
+from ..chat_session import (
+    chat_session,
+    initial_message,
+    invalidate_chat,
+)
 
 
 class ChatHandler(Handler):
-    chat_session = ChatSession(CHAT_CACHE_LENGTH, CHAT_CACHE_PATH)
+    chat_session = chat_session
 
     def __init__(self, chat_id: str, role: SystemRole, markdown: bool) -> None:
         super().__init__(role, markdown)
@@ -104,8 +20,7 @@ class ChatHandler(Handler):
         self.role = role
 
         if chat_id == "temp":
-            # If the chat id is "temp", we don't want to save the chat session.
-            self.chat_session.invalidate(chat_id)
+            invalidate_chat(chat_id)
 
         self.validate()
 
@@ -116,40 +31,11 @@ class ChatHandler(Handler):
     @property
     def is_same_role(self) -> bool:
         # TODO: Should be optimized for REPL mode.
-        return self.role.same_role(self.initial_message(self.chat_id))
-
-    @classmethod
-    def initial_message(cls, chat_id: str) -> str:
-        chat_history = cls.chat_session.get_messages(chat_id)
-        return chat_history[0] if chat_history else ""
-
-    @classmethod
-    @option_callback
-    def list_ids(cls, value: str) -> None:
-        # Prints all existing chat IDs to the console.
-        for chat_id in cls.chat_session.list():
-            typer.echo(chat_id)
-
-    @classmethod
-    def show_messages(cls, chat_id: str, markdown: bool) -> None:
-        color = cfg.get("DEFAULT_COLOR")
-        if "APPLY MARKDOWN" in cls.initial_message(chat_id) and markdown:
-            theme = cfg.get("CODE_THEME")
-            for message in cls.chat_session.get_messages(chat_id):
-                if message.startswith("assistant:"):
-                    Console().print(Markdown(message, code_theme=theme))
-                else:
-                    typer.secho(message, fg=color)
-                typer.echo()
-            return
-
-        for index, message in enumerate(cls.chat_session.get_messages(chat_id)):
-            running_color = color if index % 2 == 0 else "green"
-            typer.secho(message, fg=running_color)
+        return self.role.same_role(initial_message(self.chat_id))
 
     def validate(self) -> None:
         if self.initiated:
-            chat_role_name = self.role.get_role_name(self.initial_message(self.chat_id))
+            chat_role_name = self.role.get_role_name(initial_message(self.chat_id))
             if not chat_role_name:
                 raise BadArgumentUsage(
                     f'Could not determine chat role of "{self.chat_id}"'

--- a/sgpt/handlers/repl_handler.py
+++ b/sgpt/handlers/repl_handler.py
@@ -8,6 +8,7 @@ from ..role import DefaultRoles, SystemRole
 from ..utils import run_command
 from .chat_handler import ChatHandler
 from .default_handler import DefaultHandler
+from ..chat_session import show_chat_messages
 
 
 class ReplHandler(ChatHandler):
@@ -24,7 +25,7 @@ class ReplHandler(ChatHandler):
     def handle(self, init_prompt: str, **kwargs: Any) -> None:  # type: ignore
         if self.initiated:
             rich_print(Rule(title="Chat History", style="bold magenta"))
-            self.show_messages(self.chat_id, self.markdown)
+            show_chat_messages(self.chat_id, self.markdown)
             rich_print(Rule(style="bold magenta"))
 
         info_message = (

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 from sgpt.config import cfg
 from sgpt.role import DefaultRoles, SystemRole
+from sgpt.chat_session import invalidate_chat
 
 from .utils import app, cmd_args, comp_args, mock_comp, runner
 
@@ -59,7 +60,7 @@ def test_code_chat(completion):
     ]
     chat_name = "_test"
     chat_path = Path(cfg.get("CHAT_CACHE_PATH")) / chat_name
-    chat_path.unlink(missing_ok=True)
+    invalidate_chat(chat_name)
 
     args = {"prompt": "print hello", "--code": True, "--chat": chat_name}
     result = runner.invoke(app, cmd_args(**args))
@@ -88,7 +89,7 @@ def test_code_chat(completion):
     result = runner.invoke(app, cmd_args(**args))
     assert result.exit_code == 2
     assert "Error" in result.stdout
-    chat_path.unlink()
+    invalidate_chat(chat_name)
     # TODO: Code chat can be recalled without --code option.
 
 
@@ -100,7 +101,7 @@ def test_code_repl(completion):
     ]
     chat_name = "_test"
     chat_path = Path(cfg.get("CHAT_CACHE_PATH")) / chat_name
-    chat_path.unlink(missing_ok=True)
+    invalidate_chat(chat_name)
 
     args = {"--repl": chat_name, "--code": True}
     inputs = ["__sgpt__eof__", "print hello", "also print world", "exit()"]

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -7,6 +7,7 @@ from typer.testing import CliRunner
 from sgpt import config, main
 from sgpt.__version__ import __version__
 from sgpt.role import DefaultRoles, SystemRole
+from sgpt.chat_session import invalidate_chat
 
 from .utils import app, cmd_args, comp_args, mock_comp, runner
 
@@ -44,7 +45,7 @@ def test_show_chat_use_markdown(completion, console_print):
     completion.return_value = mock_comp("ok")
     chat_name = "_test"
     chat_path = Path(cfg.get("CHAT_CACHE_PATH")) / chat_name
-    chat_path.unlink(missing_ok=True)
+    invalidate_chat(chat_name)
 
     args = {"prompt": "my number is 2", "--chat": chat_name}
     result = runner.invoke(app, cmd_args(**args))
@@ -62,7 +63,7 @@ def test_show_chat_no_use_markdown(completion, console_print):
     completion.return_value = mock_comp("ok")
     chat_name = "_test"
     chat_path = Path(cfg.get("CHAT_CACHE_PATH")) / chat_name
-    chat_path.unlink(missing_ok=True)
+    invalidate_chat(chat_name)
 
     # Flag '--code' doesn't use markdown
     args = {"prompt": "my number is 2", "--chat": chat_name, "--code": True}
@@ -80,7 +81,7 @@ def test_default_chat(completion):
     completion.side_effect = [mock_comp("ok"), mock_comp("4")]
     chat_name = "_test"
     chat_path = Path(cfg.get("CHAT_CACHE_PATH")) / chat_name
-    chat_path.unlink(missing_ok=True)
+    invalidate_chat(chat_name)
 
     args = {"prompt": "my number is 2", "--chat": chat_name}
     result = runner.invoke(app, cmd_args(**args))
@@ -124,7 +125,7 @@ def test_default_chat(completion):
     result = runner.invoke(app, cmd_args(**args))
     assert result.exit_code == 2
     assert "Error" in result.stdout
-    chat_path.unlink()
+    invalidate_chat(chat_name)
 
 
 @patch("sgpt.handlers.handler.completion")
@@ -132,7 +133,7 @@ def test_default_repl(completion):
     completion.side_effect = [mock_comp("ok"), mock_comp("8")]
     chat_name = "_test"
     chat_path = Path(cfg.get("CHAT_CACHE_PATH")) / chat_name
-    chat_path.unlink(missing_ok=True)
+    invalidate_chat(chat_name)
 
     args = {"--repl": chat_name}
     inputs = ["__sgpt__eof__", "my number is 6", "my number + 2?", "exit()"]
@@ -161,7 +162,7 @@ def test_default_repl_stdin(completion):
     completion.side_effect = [mock_comp("ok init"), mock_comp("ok another")]
     chat_name = "_test"
     chat_path = Path(cfg.get("CHAT_CACHE_PATH")) / chat_name
-    chat_path.unlink(missing_ok=True)
+    invalidate_chat(chat_name)
 
     my_runner = CliRunner()
     my_app = typer.Typer()

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from sgpt.config import cfg
 from sgpt.role import DefaultRoles, SystemRole
+from sgpt.chat_session import invalidate_chat
 
 from .utils import app, cmd_args, comp_args, mock_comp, runner
 
@@ -101,7 +102,7 @@ def test_shell_chat(completion):
     role = SystemRole.get(DefaultRoles.SHELL.value)
     chat_name = "_test"
     chat_path = Path(cfg.get("CHAT_CACHE_PATH")) / chat_name
-    chat_path.unlink(missing_ok=True)
+    invalidate_chat(chat_name)
 
     args = {"prompt": "list folder", "--shell": True, "--chat": chat_name}
     result = runner.invoke(app, cmd_args(**args))
@@ -129,7 +130,7 @@ def test_shell_chat(completion):
     result = runner.invoke(app, cmd_args(**args))
     assert result.exit_code == 2
     assert "Error" in result.stdout
-    chat_path.unlink()
+    invalidate_chat(chat_name)
     # TODO: Shell chat can be recalled without --shell option.
 
 
@@ -140,7 +141,7 @@ def test_shell_repl(completion, mock_system):
     role = SystemRole.get(DefaultRoles.SHELL.value)
     chat_name = "_test"
     chat_path = Path(cfg.get("CHAT_CACHE_PATH")) / chat_name
-    chat_path.unlink(missing_ok=True)
+    invalidate_chat(chat_name)
 
     args = {"--repl": chat_name, "--shell": True}
     inputs = ["__sgpt__eof__", "list folder", "sort by name", "e", "exit()"]


### PR DESCRIPTION
## Summary
- move `ChatSession` into new `sgpt.chat_session` module
- import shared chat utilities in handlers and app
- update tests to use `chat_session` helper functions

## Testing
- `pytest` *(fails: No such command '--no-cache' etc.)*


------
https://chatgpt.com/codex/tasks/task_b_68ba8c55f974832ba741bdad9ac5adec