### PR TITLE
Refactor handler around pluggable LLM client

### DIFF
--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -172,6 +172,7 @@ def main(
             if "__sgpt__eof__" in line:
                 break
             stdin += line
+        stdin = stdin.rstrip("\n")
         prompt = f"{stdin}\n\n{prompt}" if prompt else stdin
         try:
             # Switch to stdin for interactive input.

--- a/sgpt/handlers/chat_handler.py
+++ b/sgpt/handlers/chat_handler.py
@@ -8,6 +8,7 @@ from rich.console import Console
 from rich.markdown import Markdown
 
 from ..config import cfg
+from ..llm_client import LLMClient
 from ..role import DefaultRoles, SystemRole
 from ..utils import option_callback
 from .handler import Handler
@@ -98,8 +99,14 @@ class ChatSession:
 class ChatHandler(Handler):
     chat_session = ChatSession(CHAT_CACHE_LENGTH, CHAT_CACHE_PATH)
 
-    def __init__(self, chat_id: str, role: SystemRole, markdown: bool) -> None:
-        super().__init__(role, markdown)
+    def __init__(
+        self,
+        chat_id: str,
+        role: SystemRole,
+        markdown: bool,
+        client: Optional[LLMClient] = None,
+    ) -> None:
+        super().__init__(role, markdown, client)
         self.chat_id = chat_id
         self.role = role
 

--- a/sgpt/handlers/default_handler.py
+++ b/sgpt/handlers/default_handler.py
@@ -1,7 +1,8 @@
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from ..config import cfg
+from ..llm_client import LLMClient
 from ..role import SystemRole
 from .handler import Handler
 
@@ -10,8 +11,13 @@ CHAT_CACHE_PATH = Path(cfg.get("CHAT_CACHE_PATH"))
 
 
 class DefaultHandler(Handler):
-    def __init__(self, role: SystemRole, markdown: bool) -> None:
-        super().__init__(role, markdown)
+    def __init__(
+        self,
+        role: SystemRole,
+        markdown: bool,
+        client: Optional[LLMClient] = None,
+    ) -> None:
+        super().__init__(role, markdown, client)
         self.role = role
 
     def make_messages(self, prompt: str) -> List[Dict[str, str]]:

--- a/sgpt/handlers/repl_handler.py
+++ b/sgpt/handlers/repl_handler.py
@@ -1,9 +1,10 @@
-from typing import Any
+from typing import Any, Optional
 
 import typer
 from rich import print as rich_print
 from rich.rule import Rule
 
+from ..llm_client import LLMClient
 from ..role import DefaultRoles, SystemRole
 from ..utils import run_command
 from .chat_handler import ChatHandler
@@ -11,8 +12,14 @@ from .default_handler import DefaultHandler
 
 
 class ReplHandler(ChatHandler):
-    def __init__(self, chat_id: str, role: SystemRole, markdown: bool) -> None:
-        super().__init__(chat_id, role, markdown)
+    def __init__(
+        self,
+        chat_id: str,
+        role: SystemRole,
+        markdown: bool,
+        client: Optional[LLMClient] = None,
+    ) -> None:
+        super().__init__(chat_id, role, markdown, client)
 
     @classmethod
     def _get_multiline_input(cls) -> str:

--- a/sgpt/llm_client.py
+++ b/sgpt/llm_client.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from .config import cfg
+
+
+class LLMClient:
+    """Client responsible for providing LLM completions."""
+
+    def __init__(self) -> None:
+        base_url = cfg.get("API_BASE_URL")
+        self.use_litellm = cfg.get("USE_LITELLM") == "true"
+        self.additional_kwargs: dict[str, Any] = {
+            "timeout": int(cfg.get("REQUEST_TIMEOUT")),
+            "api_key": cfg.get("OPENAI_API_KEY"),
+            "base_url": None if base_url == "default" else base_url,
+        }
+
+        if self.use_litellm:
+            import litellm  # type: ignore
+
+            litellm.suppress_debug_info = True
+            self.completion_fn: Callable[..., Any] = litellm.completion
+            # LiteLLM uses environment variables for auth
+            self.additional_kwargs.pop("api_key")
+        else:
+            from openai import OpenAI
+
+            client = OpenAI(**self.additional_kwargs)  # type: ignore
+            self.completion_fn = client.chat.completions.create
+            # OpenAI client is preconfigured with kwargs above
+            self.additional_kwargs = {}
+
+    def completion(self, **kwargs: Any) -> Any:
+        return self.completion_fn(**kwargs, **self.additional_kwargs)
+
+
+def get_llm_client() -> LLMClient:
+    """Factory returning configured ``LLMClient`` instance."""
+
+    return LLMClient()

--- a/tests/_integration.py
+++ b/tests/_integration.py
@@ -400,10 +400,10 @@ class TestShellGpt(TestCase):
     def test_color_output(self):
         color = cfg.get("DEFAULT_COLOR")
         role = SystemRole.get("ShellGPT")
-        handler = Handler(role=role)
+        handler = Handler(role=role, markdown=False)
         assert handler.color == color
         os.environ["DEFAULT_COLOR"] = "red"
-        handler = Handler(role=role)
+        handler = Handler(role=role, markdown=False)
         assert handler.color == "red"
 
     def test_simple_stdin(self):

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -9,7 +9,7 @@ from .utils import app, cmd_args, comp_args, mock_comp, runner
 role = SystemRole.get(DefaultRoles.CODE.value)
 
 
-@patch("sgpt.handlers.handler.completion")
+@patch("sgpt.llm_client.LLMClient.completion")
 def test_code_generation(completion):
     completion.return_value = mock_comp("print('Hello World')")
 
@@ -23,7 +23,7 @@ def test_code_generation(completion):
 
 @patch("sgpt.printer.TextPrinter.live_print")
 @patch("sgpt.printer.MarkdownPrinter.live_print")
-@patch("sgpt.handlers.handler.completion")
+@patch("sgpt.llm_client.LLMClient.completion")
 def test_code_generation_no_markdown(completion, markdown_printer, text_printer):
     completion.return_value = mock_comp("print('Hello World')")
 
@@ -36,7 +36,7 @@ def test_code_generation_no_markdown(completion, markdown_printer, text_printer)
     text_printer.assert_called()
 
 
-@patch("sgpt.handlers.handler.completion")
+@patch("sgpt.llm_client.LLMClient.completion")
 def test_code_generation_stdin(completion):
     completion.return_value = mock_comp("# Hello\nprint('Hello')")
 
@@ -51,7 +51,7 @@ def test_code_generation_stdin(completion):
     assert "print('Hello')" in result.stdout
 
 
-@patch("sgpt.handlers.handler.completion")
+@patch("sgpt.llm_client.LLMClient.completion")
 def test_code_chat(completion):
     completion.side_effect = [
         mock_comp("print('hello')"),
@@ -87,12 +87,12 @@ def test_code_chat(completion):
     args["--shell"] = True
     result = runner.invoke(app, cmd_args(**args))
     assert result.exit_code == 2
-    assert "Error" in result.stdout
+    assert "Error" in result.stderr
     chat_path.unlink()
     # TODO: Code chat can be recalled without --code option.
 
 
-@patch("sgpt.handlers.handler.completion")
+@patch("sgpt.llm_client.LLMClient.completion")
 def test_code_repl(completion):
     completion.side_effect = [
         mock_comp("print('hello')"),
@@ -124,21 +124,21 @@ def test_code_repl(completion):
     assert "print('world')" in result.stdout
 
 
-@patch("sgpt.handlers.handler.completion")
+@patch("sgpt.llm_client.LLMClient.completion")
 def test_code_and_shell(completion):
     args = {"--code": True, "--shell": True}
     result = runner.invoke(app, cmd_args(**args))
 
     completion.assert_not_called()
     assert result.exit_code == 2
-    assert "Error" in result.stdout
+    assert "Error" in result.stderr
 
 
-@patch("sgpt.handlers.handler.completion")
+@patch("sgpt.llm_client.LLMClient.completion")
 def test_code_and_describe_shell(completion):
     args = {"--code": True, "--describe-shell": True}
     result = runner.invoke(app, cmd_args(**args))
 
     completion.assert_not_called()
     assert result.exit_code == 2
-    assert "Error" in result.stdout
+    assert "Error" in result.stderr

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -14,7 +14,7 @@ role = SystemRole.get(DefaultRoles.DEFAULT.value)
 cfg = config.cfg
 
 
-@patch("sgpt.handlers.handler.completion")
+@patch("sgpt.llm_client.LLMClient.completion")
 def test_default(completion):
     completion.return_value = mock_comp("Prague")
 
@@ -26,7 +26,7 @@ def test_default(completion):
     assert "Prague" in result.stdout
 
 
-@patch("sgpt.handlers.handler.completion")
+@patch("sgpt.llm_client.LLMClient.completion")
 def test_default_stdin(completion):
     completion.return_value = mock_comp("Prague")
 
@@ -39,7 +39,7 @@ def test_default_stdin(completion):
 
 
 @patch("rich.console.Console.print")
-@patch("sgpt.handlers.handler.completion")
+@patch("sgpt.llm_client.LLMClient.completion")
 def test_show_chat_use_markdown(completion, console_print):
     completion.return_value = mock_comp("ok")
     chat_name = "_test"
@@ -57,7 +57,7 @@ def test_show_chat_use_markdown(completion, console_print):
 
 
 @patch("rich.console.Console.print")
-@patch("sgpt.handlers.handler.completion")
+@patch("sgpt.llm_client.LLMClient.completion")
 def test_show_chat_no_use_markdown(completion, console_print):
     completion.return_value = mock_comp("ok")
     chat_name = "_test"
@@ -75,7 +75,7 @@ def test_show_chat_no_use_markdown(completion, console_print):
     console_print.assert_not_called()
 
 
-@patch("sgpt.handlers.handler.completion")
+@patch("sgpt.llm_client.LLMClient.completion")
 def test_default_chat(completion):
     completion.side_effect = [mock_comp("ok"), mock_comp("4")]
     chat_name = "_test"
@@ -118,16 +118,16 @@ def test_default_chat(completion):
     args["--shell"] = True
     result = runner.invoke(app, cmd_args(**args))
     assert result.exit_code == 2
-    assert "Error" in result.stdout
+    assert "Error" in result.stderr
 
     args["--code"] = True
     result = runner.invoke(app, cmd_args(**args))
     assert result.exit_code == 2
-    assert "Error" in result.stdout
+    assert "Error" in result.stderr
     chat_path.unlink()
 
 
-@patch("sgpt.handlers.handler.completion")
+@patch("sgpt.llm_client.LLMClient.completion")
 def test_default_repl(completion):
     completion.side_effect = [mock_comp("ok"), mock_comp("8")]
     chat_name = "_test"
@@ -156,7 +156,7 @@ def test_default_repl(completion):
     assert "8" in result.stdout
 
 
-@patch("sgpt.handlers.handler.completion")
+@patch("sgpt.llm_client.LLMClient.completion")
 def test_default_repl_stdin(completion):
     completion.side_effect = [mock_comp("ok init"), mock_comp("ok another")]
     chat_name = "_test"
@@ -173,7 +173,7 @@ def test_default_repl_stdin(completion):
 
     expected_messages = [
         {"role": "system", "content": role.role},
-        {"role": "user", "content": "this is stdin\n\n\n\nprompt"},
+        {"role": "user", "content": "this is stdin\n\n\nprompt"},
         {"role": "assistant", "content": "ok init"},
         {"role": "user", "content": "another"},
         {"role": "assistant", "content": "ok another"},
@@ -190,7 +190,7 @@ def test_default_repl_stdin(completion):
     assert "ok another" in result.stdout
 
 
-@patch("sgpt.handlers.handler.completion")
+@patch("sgpt.llm_client.LLMClient.completion")
 def test_llm_options(completion):
     completion.return_value = mock_comp("Berlin")
 
@@ -215,7 +215,7 @@ def test_llm_options(completion):
     assert "Berlin" in result.stdout
 
 
-@patch("sgpt.handlers.handler.completion")
+@patch("sgpt.llm_client.LLMClient.completion")
 def test_version(completion):
     args = {"--version": True}
     result = runner.invoke(app, cmd_args(**args))
@@ -226,7 +226,7 @@ def test_version(completion):
 
 @patch("sgpt.printer.TextPrinter.live_print")
 @patch("sgpt.printer.MarkdownPrinter.live_print")
-@patch("sgpt.handlers.handler.completion")
+@patch("sgpt.llm_client.LLMClient.completion")
 def test_markdown(completion, markdown_printer, text_printer):
     completion.return_value = mock_comp("pong")
 
@@ -239,7 +239,7 @@ def test_markdown(completion, markdown_printer, text_printer):
 
 @patch("sgpt.printer.TextPrinter.live_print")
 @patch("sgpt.printer.MarkdownPrinter.live_print")
-@patch("sgpt.handlers.handler.completion")
+@patch("sgpt.llm_client.LLMClient.completion")
 def test_no_markdown(completion, markdown_printer, text_printer):
     completion.return_value = mock_comp("pong")
 

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -8,7 +8,7 @@ from sgpt.role import SystemRole
 from .utils import app, cmd_args, comp_args, mock_comp, runner
 
 
-@patch("sgpt.handlers.handler.completion")
+@patch("sgpt.llm_client.LLMClient.completion")
 def test_role(completion):
     completion.return_value = mock_comp('{"foo": "bar"}')
     path = Path(cfg.get("ROLE_STORAGE_PATH")) / "json_gen_test.json"

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -8,13 +8,13 @@ from sgpt.role import DefaultRoles, SystemRole
 from .utils import app, cmd_args, comp_args, mock_comp, runner
 
 
-@patch("sgpt.handlers.handler.completion")
+@patch("sgpt.llm_client.LLMClient.completion")
 def test_shell(completion):
     role = SystemRole.get(DefaultRoles.SHELL.value)
     completion.return_value = mock_comp("git commit -m test")
 
     args = {"prompt": "make a commit using git", "--shell": True}
-    result = runner.invoke(app, cmd_args(**args))
+    result = runner.invoke(app, cmd_args(**args), input="__sgpt__eof__\na\n")
 
     completion.assert_called_once_with(**comp_args(role, args["prompt"]))
     assert result.exit_code == 0
@@ -24,12 +24,12 @@ def test_shell(completion):
 
 @patch("sgpt.printer.TextPrinter.live_print")
 @patch("sgpt.printer.MarkdownPrinter.live_print")
-@patch("sgpt.handlers.handler.completion")
+@patch("sgpt.llm_client.LLMClient.completion")
 def test_shell_no_markdown(completion, markdown_printer, text_printer):
     completion.return_value = mock_comp("git commit -m test")
 
     args = {"prompt": "make a commit using git", "--shell": True, "--md": True}
-    result = runner.invoke(app, cmd_args(**args))
+    result = runner.invoke(app, cmd_args(**args), input="__sgpt__eof__\na\n")
 
     assert result.exit_code == 0
     # Should ignore --md for --shell option and output text without markdown.
@@ -37,14 +37,14 @@ def test_shell_no_markdown(completion, markdown_printer, text_printer):
     text_printer.assert_called()
 
 
-@patch("sgpt.handlers.handler.completion")
+@patch("sgpt.llm_client.LLMClient.completion")
 def test_shell_stdin(completion):
     completion.return_value = mock_comp("ls -l | sort")
     role = SystemRole.get(DefaultRoles.SHELL.value)
 
     args = {"prompt": "Sort by name", "--shell": True}
     stdin = "What is in current folder"
-    result = runner.invoke(app, cmd_args(**args), input=stdin)
+    result = runner.invoke(app, cmd_args(**args), input=f"{stdin}\n__sgpt__eof__\na\n")
 
     expected_prompt = f"{stdin}\n\n{args['prompt']}"
     completion.assert_called_once_with(**comp_args(role, expected_prompt))
@@ -53,20 +53,20 @@ def test_shell_stdin(completion):
     assert "[E]xecute, [M]odify, [D]escribe, [A]bort:" in result.stdout
 
 
-@patch("sgpt.handlers.handler.completion")
+@patch("sgpt.llm_client.LLMClient.completion")
 def test_describe_shell(completion):
     completion.return_value = mock_comp("lists the contents of a folder")
     role = SystemRole.get(DefaultRoles.DESCRIBE_SHELL.value)
 
     args = {"prompt": "ls", "--describe-shell": True}
-    result = runner.invoke(app, cmd_args(**args))
+    result = runner.invoke(app, cmd_args(**args), input="__sgpt__eof__\na\n")
 
     completion.assert_called_once_with(**comp_args(role, args["prompt"]))
     assert result.exit_code == 0
     assert "lists" in result.stdout
 
 
-@patch("sgpt.handlers.handler.completion")
+@patch("sgpt.llm_client.LLMClient.completion")
 def test_describe_shell_stdin(completion):
     completion.return_value = mock_comp("lists the contents of a folder")
     role = SystemRole.get(DefaultRoles.DESCRIBE_SHELL.value)
@@ -82,7 +82,7 @@ def test_describe_shell_stdin(completion):
 
 
 @patch("os.system")
-@patch("sgpt.handlers.handler.completion")
+@patch("sgpt.llm_client.LLMClient.completion")
 def test_shell_run_description(completion, system):
     completion.side_effect = [mock_comp("echo hello"), mock_comp("prints hello")]
     args = {"prompt": "echo hello", "--shell": True}
@@ -95,7 +95,7 @@ def test_shell_run_description(completion, system):
     assert "prints hello" in result.stdout
 
 
-@patch("sgpt.handlers.handler.completion")
+@patch("sgpt.llm_client.LLMClient.completion")
 def test_shell_chat(completion):
     completion.side_effect = [mock_comp("ls"), mock_comp("ls | sort")]
     role = SystemRole.get(DefaultRoles.SHELL.value)
@@ -104,13 +104,13 @@ def test_shell_chat(completion):
     chat_path.unlink(missing_ok=True)
 
     args = {"prompt": "list folder", "--shell": True, "--chat": chat_name}
-    result = runner.invoke(app, cmd_args(**args))
+    result = runner.invoke(app, cmd_args(**args), input="__sgpt__eof__\na\n")
     assert result.exit_code == 0
     assert "ls" in result.stdout
     assert chat_path.exists()
 
     args["prompt"] = "sort by name"
-    result = runner.invoke(app, cmd_args(**args))
+    result = runner.invoke(app, cmd_args(**args), input="__sgpt__eof__\na\n")
     assert result.exit_code == 0
     assert "ls | sort" in result.stdout
 
@@ -128,13 +128,13 @@ def test_shell_chat(completion):
     args["--code"] = True
     result = runner.invoke(app, cmd_args(**args))
     assert result.exit_code == 2
-    assert "Error" in result.stdout
+    assert "Error" in result.stderr
     chat_path.unlink()
     # TODO: Shell chat can be recalled without --shell option.
 
 
 @patch("os.system")
-@patch("sgpt.handlers.handler.completion")
+@patch("sgpt.llm_client.LLMClient.completion")
 def test_shell_repl(completion, mock_system):
     completion.side_effect = [mock_comp("ls"), mock_comp("ls | sort")]
     role = SystemRole.get(DefaultRoles.SHELL.value)
@@ -166,17 +166,17 @@ def test_shell_repl(completion, mock_system):
     assert "ls | sort" in result.stdout
 
 
-@patch("sgpt.handlers.handler.completion")
+@patch("sgpt.llm_client.LLMClient.completion")
 def test_shell_and_describe_shell(completion):
     args = {"prompt": "ls", "--describe-shell": True, "--shell": True}
     result = runner.invoke(app, cmd_args(**args))
 
     completion.assert_not_called()
     assert result.exit_code == 2
-    assert "Error" in result.stdout
+    assert "Error" in result.stderr
 
 
-@patch("sgpt.handlers.handler.completion")
+@patch("sgpt.llm_client.LLMClient.completion")
 def test_shell_no_interaction(completion):
     completion.return_value = mock_comp("git commit -m test")
     role = SystemRole.get(DefaultRoles.SHELL.value)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,10 +6,23 @@ from openai.types.chat.chat_completion_chunk import Choice as StreamChoice
 from openai.types.chat.chat_completion_chunk import ChoiceDelta
 from typer.testing import CliRunner
 
+
+class SGPTRunner(CliRunner):
+    """CliRunner providing empty stdin by default."""
+
+    def invoke(self, *args, **kwargs):  # type: ignore[override]
+        input_text = kwargs.get("input", "")
+        if "__sgpt__eof__" not in input_text:
+            if not input_text.endswith("\n"):
+                input_text += "\n"
+            input_text += "__sgpt__eof__\n"
+        kwargs["input"] = input_text
+        return super().invoke(*args, **kwargs)
+
 from sgpt import main
 from sgpt.config import cfg
 
-runner = CliRunner()
+runner = SGPTRunner()
 app = typer.Typer()
 app.command()(main)
 


### PR DESCRIPTION
## Summary
- add `LLMClient` factory encapsulating OpenAI/LiteLLM setup
- inject LLM client into `Handler` and sub-classes
- normalize stdin handling and test runner to avoid EOF prompts

## Testing
- `OPENAI_API_KEY=dummy pytest`

------
https://chatgpt.com/codex/tasks/task_b_68ba8c26ee64832b9c3be86afa2dfdf6