### PR TITLE
Rename project and package to BlueShell/blu-shell

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
-# Contributing to ShellGPT
-Thank you for considering contributing to ShellGPT! To ensure a smooth and enjoyable experience for everyone, please follow the steps outlined below.
+# Contributing to BlueShell
+Thank you for considering contributing to BlueShell! To ensure a smooth and enjoyable experience for everyone, please follow the steps outlined below.
 
 ## Find an Issue to Work On
 - First, browse the existing issues to find one that interests you. If you find an issue you'd like to work on, assign it to yourself and leave a comment expressing your interest.
@@ -7,7 +7,7 @@ Thank you for considering contributing to ShellGPT! To ensure a smooth and enjoy
 - If there is an urgent issue, such as a critical bug causing the app to crash, create a pull request immediately.
 
 ## Development
-ShellGPT is written with strict types, so you'll need to define types. The project uses several linting and testing tools: ruff, mypy, isort, black, and pytest.
+BlueShell is written with strict types, so you'll need to define types. The project uses several linting and testing tools: ruff, mypy, isort, black, and pytest.
 
 ### Virtual Environment
 Create and activate a virtual environment using Python venv:
@@ -27,12 +27,12 @@ pip install -e ."[dev,test]"
 With your environment set up and the issue assigned, you can start working on your solution. Get to know the existing codebase and adhere to the project's coding style and conventions. Write clean, modular, and maintainable code to facilitate understanding and review. Commit your changes frequently to document your progress.
 
 ### Testing
-**This is a crucial step.** Any changes that implement a new feature or modify existing features should include tests. **Unverified code will not be merged.** These tests should call `sgpt` with defined arguments, capture the output, and verify that the feature works as expected. Refer to the `tests` folder for examples.
+**This is a crucial step.** Any changes that implement a new feature or modify existing features should include tests. **Unverified code will not be merged.** These tests should call `blus` with defined arguments, capture the output, and verify that the feature works as expected. Refer to the `tests` folder for examples.
 
 ### Pull Request
 Before creating a pull request, run `scripts/lint.sh` and `scripts/tests.sh` to ensure all linters and tests pass. In your pull request, provide a high-level description of your changes and detailed instructions for testing them, including any necessary commands.
 
 ### Code Review
-After submitting your pull request, be patient and receptive to feedback from reviewers. Address any concerns they raise and collaborate to refine the code. Together, we can enhance the ShellGPT project.
+After submitting your pull request, be patient and receptive to feedback from reviewers. Address any concerns they raise and collaborate to refine the code. Together, we can enhance BlueShell.
 
 Thank you once again for your contribution! We're excited to have you join us.

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ WORKDIR /app
 COPY . /app
 
 RUN apt-get update && apt-get install -y gcc
-RUN pip install --no-cache /app && mkdir -p /tmp/shell_gpt
+RUN pip install --no-cache /app && mkdir -p /tmp/blu-shell
 
-VOLUME /tmp/shell_gpt
+VOLUME /tmp/blu-shell
 
-ENTRYPOINT ["sgpt"]
+ENTRYPOINT ["blus"]

--- a/README.md
+++ b/README.md
@@ -1,35 +1,35 @@
-# ShellGPT
+# BlueShell
 A command-line productivity tool powered by AI large language models (LLM). This command-line tool offers streamlined generation of **shell commands, code snippets, documentation**, eliminating the need for external resources (like Google search). Supports Linux, macOS, Windows and compatible with all major Shells like PowerShell, CMD, Bash, Zsh, etc.
 
-https://github.com/TheR1D/shell_gpt/assets/16740832/9197283c-db6a-4b46-bfea-3eb776dd9093
+https://github.com/TheR1D/blu-shell/assets/16740832/9197283c-db6a-4b46-bfea-3eb776dd9093
 
 ## Installation
 ```shell
-pip install shell-gpt
+pip install blu-shell
 ```
-By default, ShellGPT uses OpenAI's API and GPT-4 model. You'll need an API key, you can generate one [here](https://beta.openai.com/account/api-keys). You will be prompted for your key which will then be stored in `~/.config/shell_gpt/.sgptrc`. OpenAI API is not free of charge, please refer to the [OpenAI pricing](https://openai.com/pricing) for more information.
+By default, BlueShell uses OpenAI's API and GPT-4 model. You'll need an API key, you can generate one [here](https://beta.openai.com/account/api-keys). You will be prompted for your key which will then be stored in `~/.config/blu-shell/.blusrc`. OpenAI API is not free of charge, please refer to the [OpenAI pricing](https://openai.com/pricing) for more information.
 
 > [!TIP]
-> Alternatively, you can use locally hosted open source models which are available for free. To use local models, you will need to run your own LLM backend server such as [Ollama](https://github.com/ollama/ollama). To set up ShellGPT with Ollama, please follow this comprehensive [guide](https://github.com/TheR1D/shell_gpt/wiki/Ollama).
+> Alternatively, you can use locally hosted open source models which are available for free. To use local models, you will need to run your own LLM backend server such as [Ollama](https://github.com/ollama/ollama). To set up BlueShell with Ollama, please follow this comprehensive [guide](https://github.com/TheR1D/blu-shell/wiki/Ollama).
 >
-> **❗️Note that ShellGPT is not optimized for local models and may not work as expected.**
+> **❗️Note that BlueShell is not optimized for local models and may not work as expected.**
 
 ## Usage
-**ShellGPT** is designed to quickly analyse and retrieve information. It's useful for straightforward requests ranging from technical configurations to general knowledge.
+**BlueShell** is designed to quickly analyse and retrieve information. It's useful for straightforward requests ranging from technical configurations to general knowledge.
 ```shell
-sgpt "What is the fibonacci sequence"
+blus "What is the fibonacci sequence"
 # -> The Fibonacci sequence is a series of numbers where each number ...
 ```
 
-ShellGPT accepts prompt from both stdin and command line argument. Whether you prefer piping input through the terminal or specifying it directly as arguments, `sgpt` got you covered. For example, you can easily generate a git commit message based on a diff:
+BlueShell accepts prompt from both stdin and command line argument. Whether you prefer piping input through the terminal or specifying it directly as arguments, `blus` got you covered. For example, you can easily generate a git commit message based on a diff:
 ```shell
-git diff | sgpt "Generate git commit message, for my changes"
+git diff | blus "Generate git commit message, for my changes"
 # -> Added main feature details into README.md
 ```
 
 You can analyze logs from various sources by passing them using stdin, along with a prompt. For instance, we can use it to quickly analyze logs, identify errors and get suggestions for possible solutions:
 ```shell
-docker logs -n 20 my_app | sgpt "check logs, find errors, provide possible solutions"
+docker logs -n 20 my_app | blus "check logs, find errors, provide possible solutions"
 ```
 ```text
 Error Detected: Connection timeout at line 7.
@@ -40,14 +40,14 @@ Possible Solution: Consider increasing memory allocation or optimizing applicati
 
 You can also use all kind of redirection operators to pass input:
 ```shell
-sgpt "summarise" < document.txt
+blus "summarise" < document.txt
 # -> The document discusses the impact...
-sgpt << EOF
+blus << EOF
 What is the best way to lear Golang?
 Provide simple hello world example.
 EOF
 # -> The best way to learn Golang...
-sgpt <<< "What is the best way to learn shell redirects?"
+blus <<< "What is the best way to learn shell redirects?"
 # -> The best way to learn shell redirects is through...
 ```
 
@@ -55,35 +55,35 @@ sgpt <<< "What is the best way to learn shell redirects?"
 ### Shell commands
 Have you ever found yourself forgetting common shell commands, such as `find`, and needing to look up the syntax online? With `--shell` or shortcut `-s` option, you can quickly generate and execute the commands you need right in the terminal.
 ```shell
-sgpt --shell "find all json files in current folder"
+blus --shell "find all json files in current folder"
 # -> find . -type f -name "*.json"
 # -> [E]xecute, [D]escribe, [A]bort: e
 ```
 
-Shell GPT is aware of OS and `$SHELL` you are using, it will provide shell command for specific system you have. For instance, if you ask `sgpt` to update your system, it will return a command based on your OS. Here's an example using macOS:
+BlueShell is aware of OS and `$SHELL` you are using, it will provide shell command for specific system you have. For instance, if you ask `blus` to update your system, it will return a command based on your OS. Here's an example using macOS:
 ```shell
-sgpt -s "update my system"
+blus -s "update my system"
 # -> sudo softwareupdate -i -a
 # -> [E]xecute, [D]escribe, [A]bort: e
 ```
 
 The same prompt, when used on Ubuntu, will generate a different suggestion:
 ```shell
-sgpt -s "update my system"
+blus -s "update my system"
 # -> sudo apt update && sudo apt upgrade -y
 # -> [E]xecute, [D]escribe, [A]bort: e
 ```
 
 Let's try it with Docker:
 ```shell
-sgpt -s "start nginx container, mount ./index.html"
+blus -s "start nginx container, mount ./index.html"
 # -> docker run -d -p 80:80 -v $(pwd)/index.html:/usr/share/nginx/html/index.html nginx
 # -> [E]xecute, [D]escribe, [A]bort: e
 ```
 
-We can still use pipes to pass input to `sgpt` and generate shell commands:
+We can still use pipes to pass input to `blus` and generate shell commands:
 ```shell
-sgpt -s "POST localhost with" < data.json
+blus -s "POST localhost with" < data.json
 # -> curl -X POST -H "Content-Type: application/json" -d '{"a": 1, "b": 2}' http://localhost
 # -> [E]xecute, [D]escribe, [A]bort: e
 ```
@@ -92,28 +92,28 @@ Applying additional shell magic in our prompt, in this example passing file name
 ```shell
 ls
 # -> 1.mp4 2.mp4 3.mp4
-sgpt -s "ffmpeg combine $(ls -m) into one video file without audio."
+blus -s "ffmpeg combine $(ls -m) into one video file without audio."
 # -> ffmpeg -i 1.mp4 -i 2.mp4 -i 3.mp4 -filter_complex "[0:v] [1:v] [2:v] concat=n=3:v=1 [v]" -map "[v]" out.mp4
 # -> [E]xecute, [D]escribe, [A]bort: e
 ```
 
 If you would like to pass generated shell command using pipe, you can use `--no-interaction` option. This will disable interactive mode and will print generated command to stdout. In this example we are using `pbcopy` to copy generated command to clipboard:
 ```shell
-sgpt -s "find all json files in current folder" --no-interaction | pbcopy
+blus -s "find all json files in current folder" --no-interaction | pbcopy
 ```
 
 
 ### Shell integration
-This is a **very handy feature**, which allows you to use `sgpt` shell completions directly in your terminal, without the need to type `sgpt` with prompt and arguments. Shell integration enables the use of ShellGPT with hotkeys in your terminal, supported by both Bash and ZSH shells. This feature puts `sgpt` completions directly into terminal buffer (input line), allowing for immediate editing of suggested commands.
+This is a **very handy feature**, which allows you to use `blus` shell completions directly in your terminal, without the need to type `blus` with prompt and arguments. Shell integration enables the use of BlueShell with hotkeys in your terminal, supported by both Bash and ZSH shells. This feature puts `blus` completions directly into terminal buffer (input line), allowing for immediate editing of suggested commands.
 
-https://github.com/TheR1D/shell_gpt/assets/16740832/bead0dab-0dd9-436d-88b7-6abfb2c556c1
+https://github.com/TheR1D/blu-shell/assets/16740832/bead0dab-0dd9-436d-88b7-6abfb2c556c1
 
-To install shell integration, run `sgpt --install-integration` and restart your terminal to apply changes. This will add few lines to your `.bashrc` or `.zshrc` file. After that, you can use `Ctrl+l` (by default) to invoke ShellGPT. When you press `Ctrl+l` it will replace you current input line (buffer) with suggested command. You can then edit it and just press `Enter` to execute.
+To install shell integration, run `blus --install-integration` and restart your terminal to apply changes. This will add few lines to your `.bashrc` or `.zshrc` file. After that, you can use `Ctrl+l` (by default) to invoke BlueShell. When you press `Ctrl+l` it will replace you current input line (buffer) with suggested command. You can then edit it and just press `Enter` to execute.
 
 ### Generating code
 By using the `--code` or `-c` parameter, you can specifically request pure code output, for instance:
 ```shell
-sgpt --code "solve fizz buzz problem using python"
+blus --code "solve fizz buzz problem using python"
 ```
 
 ```python
@@ -129,7 +129,7 @@ for i in range(1, 101):
 ```
 Since it is valid python code, we can redirect the output to a file:  
 ```shell
-sgpt --code "solve classic fizz buzz problem using Python" > fizz_buzz.py
+blus --code "solve classic fizz buzz problem using Python" > fizz_buzz.py
 python fizz_buzz.py
 # 1
 # 2
@@ -141,7 +141,7 @@ python fizz_buzz.py
 
 We can also use pipes to pass input:
 ```shell
-cat fizz_buzz.py | sgpt --code "Generate comments for each line of my code"
+cat fizz_buzz.py | blus --code "Generate comments for each line of my code"
 ```
 ```python
 # Loop through numbers 1 to 100
@@ -164,19 +164,19 @@ for i in range(1, 101):
 ```
 
 ### Chat Mode 
-Often it is important to preserve and recall a conversation. `sgpt` creates conversational dialogue with each LLM completion requested. The dialogue can develop one-by-one (chat mode) or interactively, in a REPL loop (REPL mode). Both ways rely on the same underlying object, called a chat session. The session is located at the [configurable](#runtime-configuration-file) `CHAT_CACHE_PATH`.
+Often it is important to preserve and recall a conversation. `blus` creates conversational dialogue with each LLM completion requested. The dialogue can develop one-by-one (chat mode) or interactively, in a REPL loop (REPL mode). Both ways rely on the same underlying object, called a chat session. The session is located at the [configurable](#runtime-configuration-file) `CHAT_CACHE_PATH`.
 
 To start a conversation, use the `--chat` option followed by a unique session name and a prompt.
 ```shell
-sgpt --chat conversation_1 "please remember my favorite number: 4"
+blus --chat conversation_1 "please remember my favorite number: 4"
 # -> I will remember that your favorite number is 4.
-sgpt --chat conversation_1 "what would be my favorite number + 4?"
+blus --chat conversation_1 "what would be my favorite number + 4?"
 # -> Your favorite number is 4, so if we add 4 to it, the result would be 8.
 ```
 
 You can use chat sessions to iteratively improve GPT suggestions by providing additional details.  It is possible to use `--code` or `--shell` options to initiate `--chat`:
 ```shell
-sgpt --chat conversation_2 --code "make a request to localhost using python"
+blus --chat conversation_2 --code "make a request to localhost using python"
 ```
 ```python
 import requests
@@ -187,7 +187,7 @@ print(response.text)
 
 Let's ask LLM to add caching to our request:
 ```shell
-sgpt --chat conversation_2 --code "add caching"
+blus --chat conversation_2 --code "add caching"
 ```
 ```python
 import requests
@@ -202,26 +202,26 @@ print(response.text)
 
 Same applies for shell commands:
 ```shell
-sgpt --chat conversation_3 --shell "what is in current folder"
+blus --chat conversation_3 --shell "what is in current folder"
 # -> ls
-sgpt --chat conversation_3 "Sort by name"
+blus --chat conversation_3 "Sort by name"
 # -> ls | sort
-sgpt --chat conversation_3 "Concatenate them using FFMPEG"
+blus --chat conversation_3 "Concatenate them using FFMPEG"
 # -> ffmpeg -i "concat:$(ls | sort | tr '\n' '|')" -codec copy output.mp4
-sgpt --chat conversation_3 "Convert the resulting file into an MP3"
+blus --chat conversation_3 "Convert the resulting file into an MP3"
 # -> ffmpeg -i output.mp4 -vn -acodec libmp3lame -ac 2 -ab 160k -ar 48000 final_output.mp3
 ```
 
 To list all the sessions from either conversational mode, use the `--list-chats` or `-lc` option:  
 ```shell
-sgpt --list-chats
-# .../shell_gpt/chat_cache/conversation_1  
-# .../shell_gpt/chat_cache/conversation_2
+blus --list-chats
+# .../blu-shell/chat_cache/conversation_1  
+# .../blu-shell/chat_cache/conversation_2
 ```
 
 To show all the messages related to a specific conversation, use the `--show-chat` option followed by the session name:
 ```shell
-sgpt --show-chat conversation_1
+blus --show-chat conversation_1
 # user: please remember my favorite number: 4
 # assistant: I will remember that your favorite number is 4.
 # user: what would be my favorite number + 4?
@@ -236,7 +236,7 @@ There is very handy REPL (read–eval–print loop) mode, which allows you to in
 </p>
 
 ```text
-sgpt --repl temp
+blus --repl temp
 Entering REPL mode, press Ctrl+C to exit.
 >>> What is REPL?
 REPL stands for Read-Eval-Print Loop. It is a programming environment ...
@@ -246,7 +246,7 @@ To use Python with REPL, you can simply open a terminal or command prompt ...
 
 REPL mode can work with `--shell` and `--code` options, which makes it very handy for interactive shell commands and code generation:
 ```text
-sgpt --repl temp --shell
+blus --repl temp --shell
 Entering shell REPL mode, type [e] to execute commands or press Ctrl+C to exit.
 >>> What is in current folder?
 ls
@@ -259,7 +259,7 @@ ls -lhS
 
 To provide multiline prompt use triple quotes `"""`:
 ```text
-sgpt --repl temp
+blus --repl temp
 Entering REPL mode, press Ctrl+C to exit.
 >>> """
 ... Explain following code:
@@ -271,7 +271,7 @@ It is a Python script that uses the random module to generate and print a random
 
 You can also enter REPL mode with initial prompt by passing it as an argument or stdin or even both:
 ```shell
-sgpt --repl temp < my_app.py
+blus --repl temp < my_app.py
 ```
 ```text
 Entering REPL mode, press Ctrl+C to exit.
@@ -285,12 +285,12 @@ The snippet of code you've provided is written in Python. It prompts the user...
 ```
 
 ### Function calling  
-[Function calls](https://platform.openai.com/docs/guides/function-calling) is a powerful feature OpenAI provides. It allows LLM to execute functions in your system, which can be used to accomplish a variety of tasks. To install [default functions](https://github.com/TheR1D/shell_gpt/tree/main/sgpt/llm_functions/) run:
+[Function calls](https://platform.openai.com/docs/guides/function-calling) is a powerful feature OpenAI provides. It allows LLM to execute functions in your system, which can be used to accomplish a variety of tasks. To install [default functions](https://github.com/TheR1D/blu-shell/tree/main/sgpt/llm_functions/) run:
 ```shell
-sgpt --install-functions
+blus --install-functions
 ```
 
-ShellGPT has a convenient way to define functions and use them. In order to create your custom function, navigate to `~/.config/shell_gpt/functions` and create a new .py file with the function name. Inside this file, you can define your function using the following syntax:
+BlueShell has a convenient way to define functions and use them. In order to create your custom function, navigate to `~/.config/blu-shell/functions` and create a new .py file with the function name. Inside this file, you can define your function using the following syntax:
 ```python
 # execute_shell_command.py
 import subprocess
@@ -315,7 +315,7 @@ class Function(OpenAISchema):
 
 The docstring comment inside the class will be passed to OpenAI API as a description for the function, along with the `title` attribute and parameters descriptions. The `execute` function will be called if LLM decides to use your function. In this case we are allowing LLM to execute any Shell commands in our system. Since we are returning the output of the command, LLM will be able to analyze it and decide if it is a good fit for the prompt. Here is an example how the function might be executed by LLM:
 ```shell
-sgpt "What are the files in /tmp folder?"
+blus "What are the files in /tmp folder?"
 # -> @FunctionCall execute_shell_command(shell_command="ls /tmp")
 # -> The /tmp folder contains the following files and directories:
 # -> test.txt
@@ -324,7 +324,7 @@ sgpt "What are the files in /tmp folder?"
 
 Note that if for some reason the function (execute_shell_command) will return an error, LLM might try to accomplish the task based on the output. Let's say we don't have installed `jq` in our system, and we ask LLM to parse JSON file:
 ```shell
-sgpt "parse /tmp/test.json file using jq and return only email value"
+blus "parse /tmp/test.json file using jq and return only email value"
 # -> @FunctionCall execute_shell_command(shell_command="jq -r '.email' /tmp/test.json")
 # -> It appears that jq is not installed on the system. Let me try to install it using brew.
 # -> @FunctionCall execute_shell_command(shell_command="brew install jq")
@@ -335,21 +335,21 @@ sgpt "parse /tmp/test.json file using jq and return only email value"
 
 It is also possible to chain multiple function calls in the prompt:
 ```shell
-sgpt "Play music and open hacker news"
+blus "Play music and open hacker news"
 # -> @FunctionCall play_music()
 # -> @FunctionCall open_url(url="https://news.ycombinator.com")
 # -> Music is now playing, and Hacker News has been opened in your browser. Enjoy!
 ```
 
-This is just a simple example of how you can use function calls. It is truly a powerful feature that can be used to accomplish a variety of complex tasks. We have dedicated [category](https://github.com/TheR1D/shell_gpt/discussions/categories/functions) in GitHub Discussions for sharing and discussing functions. 
+This is just a simple example of how you can use function calls. It is truly a powerful feature that can be used to accomplish a variety of complex tasks. We have dedicated [category](https://github.com/TheR1D/blu-shell/discussions/categories/functions) in GitHub Discussions for sharing and discussing functions. 
 LLM might execute destructive commands, so please use it at your own risk❗️
 
 ### Roles
-ShellGPT allows you to create custom roles, which can be utilized to generate code, shell commands, or to fulfill your specific needs. To create a new role, use the `--create-role` option followed by the role name. You will be prompted to provide a description for the role, along with other details. This will create a JSON file in `~/.config/shell_gpt/roles` with the role name. Inside this directory, you can also edit default `sgpt` roles, such as **shell**, **code**, and **default**. Use the `--list-roles` option to list all available roles, and the `--show-role` option to display the details of a specific role. Here's an example of a custom role:
+BlueShell allows you to create custom roles, which can be utilized to generate code, shell commands, or to fulfill your specific needs. To create a new role, use the `--create-role` option followed by the role name. You will be prompted to provide a description for the role, along with other details. This will create a JSON file in `~/.config/blu-shell/roles` with the role name. Inside this directory, you can also edit default `blus` roles, such as **shell**, **code**, and **default**. Use the `--list-roles` option to list all available roles, and the `--show-role` option to display the details of a specific role. Here's an example of a custom role:
 ```shell
-sgpt --create-role json_generator
+blus --create-role json_generator
 # Enter role description: Provide only valid json as response.
-sgpt --role json_generator "random: user, password, email, address"
+blus --role json_generator "random: user, password, email, address"
 ```
 ```json
 {
@@ -368,17 +368,17 @@ sgpt --role json_generator "random: user, password, email, address"
 If the description of the role contains the words "APPLY MARKDOWN" (case sensitive), then chats will be displayed using markdown formatting unless it is explicitly turned off with `--no-md`.
 
 ### Request cache
-Control cache using `--cache` (default) and `--no-cache` options. This caching applies for all `sgpt` requests to OpenAI API:
+Control cache using `--cache` (default) and `--no-cache` options. This caching applies for all `blus` requests to OpenAI API:
 ```shell
-sgpt "what are the colors of a rainbow"
+blus "what are the colors of a rainbow"
 # -> The colors of a rainbow are red, orange, yellow, green, blue, indigo, and violet.
 ```
-Next time, same exact query will get results from local cache instantly. Note that `sgpt "what are the colors of a rainbow" --temperature 0.5` will make a new request, since we didn't provide `--temperature` (same applies to `--top-probability`) on previous request.
+Next time, same exact query will get results from local cache instantly. Note that `blus "what are the colors of a rainbow" --temperature 0.5` will make a new request, since we didn't provide `--temperature` (same applies to `--top-probability`) on previous request.
 
 This is just some examples of what we can do using OpenAI GPT models, I'm sure you will find it useful for your specific use cases.
 
 ### Runtime configuration file
-You can setup some parameters in runtime configuration file `~/.config/shell_gpt/.sgptrc`:
+You can setup some parameters in runtime configuration file `~/.config/blu-shell/.blusrc`:
 ```text
 # API key, also it is possible to define OPENAI_API_KEY env.
 OPENAI_API_KEY=your_api_key
@@ -387,11 +387,11 @@ API_BASE_URL=default
 # Max amount of cached message per chat session.
 CHAT_CACHE_LENGTH=100
 # Chat cache folder.
-CHAT_CACHE_PATH=/tmp/shell_gpt/chat_cache
+CHAT_CACHE_PATH=/tmp/blu-shell/chat_cache
 # Request cache length (amount).
 CACHE_LENGTH=100
 # Request cache folder.
-CACHE_PATH=/tmp/shell_gpt/cache
+CACHE_PATH=/tmp/blu-shell/cache
 # Request timeout in seconds.
 REQUEST_TIMEOUT=60
 # Default OpenAI model to use.
@@ -405,7 +405,7 @@ DISABLE_STREAMING=false
 # The pygment theme to view markdown (default/describe role).
 CODE_THEME=default
 # Path to a directory with functions.
-OPENAI_FUNCTIONS_PATH=/Users/user/.config/shell_gpt/functions
+OPENAI_FUNCTIONS_PATH=/Users/user/.config/blu-shell/functions
 # Print output of functions when LLM uses them.
 SHOW_FUNCTIONS_OUTPUT=false
 # Allows LLM to use functions.
@@ -459,27 +459,27 @@ docker run --rm \
            --env OPENAI_API_KEY=api_key \
            --env OS_NAME=$(uname -s) \
            --env SHELL_NAME=$(echo $SHELL) \
-           --volume gpt-cache:/tmp/shell_gpt \
-       ghcr.io/ther1d/shell_gpt -s "update my system"
+           --volume gpt-cache:/tmp/blu-shell \
+       ghcr.io/ther1d/blu-shell -s "update my system"
 ```
 
 Example of a conversation, using an alias and the `OPENAI_API_KEY` environment variable:
 ```shell
-alias sgpt="docker run --rm --volume gpt-cache:/tmp/shell_gpt --env OPENAI_API_KEY --env OS_NAME=$(uname -s) --env SHELL_NAME=$(echo $SHELL) ghcr.io/ther1d/shell_gpt"
+alias blus="docker run --rm --volume gpt-cache:/tmp/blu-shell --env OPENAI_API_KEY --env OS_NAME=$(uname -s) --env SHELL_NAME=$(echo $SHELL) ghcr.io/ther1d/blu-shell"
 export OPENAI_API_KEY="your OPENAI API key"
-sgpt --chat rainbow "what are the colors of a rainbow"
-sgpt --chat rainbow "inverse the list of your last answer"
-sgpt --chat rainbow "translate your last answer in french"
+blus --chat rainbow "what are the colors of a rainbow"
+blus --chat rainbow "inverse the list of your last answer"
+blus --chat rainbow "translate your last answer in french"
 ```
 
 You also can use the provided `Dockerfile` to build your own image:
 ```shell
-docker build -t sgpt .
+docker build -t blus .
 ```
 
 ### Docker + Ollama
 
-If you want to send your requests to an Ollama instance and run ShellGPT inside a Docker container, you need to adjust the Dockerfile and build the container yourself: the litellm package is needed and env variables need to be set correctly.
+If you want to send your requests to an Ollama instance and run BlueShell inside a Docker container, you need to adjust the Dockerfile and build the container yourself: the litellm package is needed and env variables need to be set correctly.
 
 Example Dockerfile:
 ```
@@ -498,14 +498,14 @@ WORKDIR /app
 COPY . /app
 
 RUN apt-get update && apt-get install -y gcc
-RUN pip install --no-cache /app[litellm] && mkdir -p /tmp/shell_gpt
+RUN pip install --no-cache /app[litellm] && mkdir -p /tmp/blu-shell
 
-VOLUME /tmp/shell_gpt
+VOLUME /tmp/blu-shell
 
-ENTRYPOINT ["sgpt"]
+ENTRYPOINT ["blus"]
 ```
 
 
 ## Additional documentation
-* [Azure integration](https://github.com/TheR1D/shell_gpt/wiki/Azure)
-* [Ollama integration](https://github.com/TheR1D/shell_gpt/wiki/Ollama)
+* [Azure integration](https://github.com/TheR1D/blu-shell/wiki/Azure)
+* [Ollama integration](https://github.com/TheR1D/blu-shell/wiki/Ollama)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "shell_gpt"
+name = "blu-shell"
 description = "A command-line productivity tool powered by large language models, will help you accomplish your tasks faster and more efficiently."
 keywords = ["shell", "gpt", "openai", "ollama", "cli", "productivity", "cheet-sheet"]
 readme = "README.md"
@@ -53,12 +53,12 @@ dev = [
 ]
 
 [project.scripts]
-sgpt = "sgpt:cli"
+blus = "sgpt:cli"
 
 [project.urls]
-homepage = "https://github.com/ther1d/shell_gpt"
-repository = "https://github.com/ther1d/shell_gpt"
-documentation = "https://github.com/TheR1D/shell_gpt/blob/main/README.md"
+homepage = "https://github.com/ther1d/blu-shell"
+repository = "https://github.com/ther1d/blu-shell"
+documentation = "https://github.com/TheR1D/blu-shell/blob/main/README.md"
 
 [tool.hatch.version]
 path = "sgpt/__version__.py"

--- a/sgpt/app.py
+++ b/sgpt/app.py
@@ -18,7 +18,7 @@ from sgpt.llm_functions.init_functions import install_functions as inst_funcs
 from sgpt.role import DefaultRoles, SystemRole
 from sgpt.utils import (
     get_edited_prompt,
-    get_sgpt_version,
+    get_blus_version,
     install_shell_integration,
     run_command,
 )
@@ -93,7 +93,7 @@ def main(
         False,
         "--version",
         help="Show version.",
-        callback=get_sgpt_version,
+        callback=get_blus_version,
     ),
     chat: str = typer.Option(
         None,
@@ -164,7 +164,7 @@ def main(
         # In some cases, we need to pass stdin along with inputs.
         # When we want part of stdin to be used as a init prompt,
         # but rest of the stdin to be used as a inputs. For example:
-        # echo "hello\n__sgpt__eof__\nThis is input" | sgpt --repl temp
+        # echo "hello\n__sgpt__eof__\nThis is input" | blus --repl temp
         # In this case, "hello" will be used as a init prompt, and
         # "This is input" will be used as "interactive" input to the REPL.
         # This is useful to test REPL with some initial context.

--- a/sgpt/config.py
+++ b/sgpt/config.py
@@ -7,8 +7,8 @@ from typing import Any
 from click import UsageError
 
 CONFIG_FOLDER = os.path.expanduser("~/.config")
-SHELL_GPT_CONFIG_FOLDER = Path(CONFIG_FOLDER) / "shell_gpt"
-SHELL_GPT_CONFIG_PATH = SHELL_GPT_CONFIG_FOLDER / ".sgptrc"
+SHELL_GPT_CONFIG_FOLDER = Path(CONFIG_FOLDER) / "blu-shell"
+SHELL_GPT_CONFIG_PATH = SHELL_GPT_CONFIG_FOLDER / ".blusrc"
 ROLE_STORAGE_PATH = SHELL_GPT_CONFIG_FOLDER / "roles"
 FUNCTIONS_PATH = SHELL_GPT_CONFIG_FOLDER / "functions"
 CHAT_CACHE_PATH = Path(gettempdir()) / "chat_cache"

--- a/sgpt/integration.py
+++ b/sgpt/integration.py
@@ -1,27 +1,27 @@
 bash_integration = """
-# Shell-GPT integration BASH v0.2
-_sgpt_bash() {
+# BlueShell integration BASH v0.2
+_blus_bash() {
 if [[ -n "$READLINE_LINE" ]]; then
-    READLINE_LINE=$(sgpt --shell <<< "$READLINE_LINE" --no-interaction)
+    READLINE_LINE=$(blus --shell <<< "$READLINE_LINE" --no-interaction)
     READLINE_POINT=${#READLINE_LINE}
 fi
 }
-bind -x '"\\C-l": _sgpt_bash'
-# Shell-GPT integration BASH v0.2
+bind -x '"\\C-l": _blus_bash'
+# BlueShell integration BASH v0.2
 """
 
 zsh_integration = """
-# Shell-GPT integration ZSH v0.2
-_sgpt_zsh() {
+# BlueShell integration ZSH v0.2
+_blus_zsh() {
 if [[ -n "$BUFFER" ]]; then
-    _sgpt_prev_cmd=$BUFFER
+    _blus_prev_cmd=$BUFFER
     BUFFER+="⌛"
     zle -I && zle redisplay
-    BUFFER=$(sgpt --shell <<< "$_sgpt_prev_cmd" --no-interaction)
+    BUFFER=$(blus --shell <<< "$_blus_prev_cmd" --no-interaction)
     zle end-of-line
 fi
 }
-zle -N _sgpt_zsh
-bindkey ^l _sgpt_zsh
-# Shell-GPT integration ZSH v0.2
+zle -N _blus_zsh
+bindkey ^l _blus_zsh
+# BlueShell integration ZSH v0.2
 """

--- a/sgpt/role.py
+++ b/sgpt/role.py
@@ -64,7 +64,7 @@ class SystemRole:
         cls.storage.parent.mkdir(parents=True, exist_ok=True)
         variables = {"shell": cls._shell_name(), "os": cls._os_name()}
         for default_role in (
-            SystemRole("ShellGPT", DEFAULT_ROLE, variables),
+            SystemRole("BlueShell", DEFAULT_ROLE, variables),
             SystemRole("Shell Command Generator", SHELL_ROLE, variables),
             SystemRole("Shell Command Descriptor", DESCRIBE_SHELL_ROLE, variables),
             SystemRole("Code Generator", CODE_ROLE),
@@ -167,7 +167,7 @@ class SystemRole:
 
 
 class DefaultRoles(Enum):
-    DEFAULT = "ShellGPT"
+    DEFAULT = "BlueShell"
     SHELL = "Shell Command Generator"
     DESCRIBE_SHELL = "Shell Command Descriptor"
     CODE = "Code Generator"

--- a/sgpt/utils.py
+++ b/sgpt/utils.py
@@ -82,14 +82,14 @@ def install_shell_integration(*_args: Any) -> None:
         with open(os.path.expanduser("~/.bashrc"), "a", encoding="utf-8") as file:
             file.write(bash_integration)
     else:
-        raise UsageError("ShellGPT integrations only available for ZSH and Bash.")
+        raise UsageError("BlueShell integrations only available for ZSH and Bash.")
 
     typer.echo("Done! Restart your shell to apply changes.")
 
 
 @option_callback
-def get_sgpt_version(*_args: Any) -> None:
+def get_blus_version(*_args: Any) -> None:
     """
-    Displays the current installed version of ShellGPT
+    Displays the current installed version of BlueShell
     """
-    typer.echo(f"ShellGPT {__version__}")
+    typer.echo(f"BlueShell {__version__}")

--- a/tests/_integration.py
+++ b/tests/_integration.py
@@ -1,7 +1,7 @@
 """
 This test module will execute real commands using shell.
-This means it will call sgpt.py with command line arguments.
-Make sure you have your API key in place ~/.cfg/shell_gpt/.sgptrc
+This means it will call blus.py with command line arguments.
+Make sure you have your API key in place ~/.cfg/blu-shell/.blusrc
 or ENV variable OPENAI_API_KEY.
 It is useful for quick tests, saves a bit time.
 """
@@ -34,7 +34,7 @@ class TestShellGpt(TestCase):
     def setUpClass(cls):
         # Response streaming should be enabled for these tests.
         assert cfg.get("DISABLE_STREAMING") == "false"
-        # ShellGPT optimised and tested with gpt-4 turbo.
+        # BlueShell optimised and tested with gpt-4 turbo.
         assert cfg.get("DEFAULT_MODEL") == "gpt-4o"
         # Make sure we will not call any functions.
         assert cfg.get("OPENAI_USE_FUNCTIONS") == "false"
@@ -399,7 +399,7 @@ class TestShellGpt(TestCase):
 
     def test_color_output(self):
         color = cfg.get("DEFAULT_COLOR")
-        role = SystemRole.get("ShellGPT")
+        role = SystemRole.get("BlueShell")
         handler = Handler(role=role)
         assert handler.color == color
         os.environ["DEFAULT_COLOR"] = "red"


### PR DESCRIPTION
## Summary
- use BlueShell as project name and rename PyPI package to `blu-shell`
- point configuration, URLs, and integration scripts to `blu-shell`
- update default role name and messaging to reference BlueShell

## Testing
- `OPENAI_API_KEY=dummy pytest` *(fails: 23 failed, 6 passed)*

------
https://chatgpt.com/codex/tasks/task_b_68ba959f329c832bae7b0cea77a7f329